### PR TITLE
Add more credit to the mod authors

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Examples
 * CritterNumberSensor: Sensor for the critter number in a room (thanks to R9MX4 from Klei forum)
 * CustomWorldMod: Enables the player to user custom world sizes. (Made by [@Moonkis](https://github.com/Moonkis), remade by [@Killface1980](https://github.com/Killface1980))
 * FastModeMod: Duplicants will build and dig very fast.
-* DisplayDraggedBoxSize: Shows selected rectangle dimensions using any tool (thanks to fistak from github)
+* DisplayDraggedBoxSize: Shows selected rectangle dimensions using any tool (thanks to [@fistak](https://github.com/fistak))
 * InstantResearchMod: Forces instant research without Debug mode.
 * InsulatedDoorsMod: Doors can be constructed using any buildable element (ie: Abyssalite). Also it adds a new element Insulated Pressure Door
 * InverseElectrolyzerMod: Combines hydrogen and oxygen into steam.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Examples
 * DraggablePanelMod: Makes panels draggable (Made by [@fistak](https://github.com/fistak)). REQUIRES ONI-Common.
 * DisplayDraggedBoxSize: Shows selected rectangle dimensions using any tool (thanks to fistak from github)
 * FastModeMod: Duplicants will build an dig very fast.
-* ImprovedGasColourMod: Replaces the oxygen overly with gas colors. Also visualizes the density (Made by [@fistak](https://github.com/fistak), modified). REQUIRES ONI-Common.
+* ImprovedGasColourMod: Replaces the oxygen overly with gas colors. Also visualizes the density (Made by [@fistak](https://github.com/fistak) and [@Killface1980](https://github.com/Killface1980)). REQUIRES ONI-Common.
 * InstantResearchMod: Forces instant research without Debug mode.
 * InsulatedDoorsMod: Doors can be constructed using any buildable element (ie: Abyssalite). Also it adds a new element Insulated Pressure Door
 * InverseElectrolyzerMod: Combines hydrogen and oxygen into steam.

--- a/README.md
+++ b/README.md
@@ -25,9 +25,6 @@ Examples
 * InsulatedDoorsMod: Doors can be constructed using any buildable element (ie: Abyssalite). Also it adds a new element Insulated Pressure Door
 * InverseElectrolyzerMod: Combines hydrogen and oxygen into steam.
 * LiquidTankMod: Storage for liquids.
-* MaterialColor: Adds an overlay option to visualize what a building is made of (Made by [@fistak](https://github.com/fistak)). REQUIRES ONI-Common.
-* ONI-Common: Common code for Onion Patches and other mods.
-* OnionPatches: Custom world seeds. DebugHandler hook. REQUIRES ONI-Common. Made by [@Moonkis](https://github.com/Moonkis)
 * Patches (Do not use): Some incomplete tests.
 * PressureDoorMod: Removes the energy need for the mechanized pressure door and makes it buildable from all material.
 * SensorsMod: Allows for increased ranges in automation sensors (Made by [@fistak](https://github.com/fistak)).

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This project uses source code of and is based on:
 Examples
 --------
 * AlternateOrdersMod: The Fabricators and Refineries will alternate between infinity orders.
-* CameraControllerMod: Enable further zoom-outs in play and dev mode (taken from [@Moonkis](https://github.com/Moonkis) Onion patcher).
+* CameraControllerMod: Enable further zoom-outs in play and dev mode (taken from [@Moonkis](https://github.com/Moonkis) Onion patcher, adapted by [@Killface1980](https://github.com/Killface1980)).
 * CritterNumberSensor: Sensor for the critter number in a room (thanks to R9MX4 from Klei forum)
 * CustomWorldMod: Enables the player to user custom world sizes. (Made by [@Moonkis](https://github.com/Moonkis), remade by [@Killface1980](https://github.com/Killface1980))
 * FastModeMod: Duplicants will build and dig very fast.
@@ -27,14 +27,14 @@ Examples
 * LiquidTankMod: Storage for liquids.
 * Patches (Do not use): Some incomplete tests.
 * PressureDoorMod: Removes the energy need for the mechanized pressure door and makes it buildable from all material.
-* SensorsMod: Allows for increased ranges in automation sensors (Made by [@fistak](https://github.com/fistak)).
+* SensorsMod: Allows for increased ranges in automation sensors (Made by [@fistak](https://github.com/fistak), adapted by [@Killface1980](https://github.com/Killface1980)).
 * SpeedControlMod: Overwrites the method SpeedControlScreen.OnChange. Fast Speed set to behave like Ultra Speed in debug mode.
 * StorageLockerMod: Storage lockers won't need a foundation to be built.
 * ONI-Common: Common code, required by these mods:
-  * DraggablePanelMod: Makes panels draggable (Made by [@fistak](https://github.com/fistak)).
+  * DraggablePanelMod: Makes panels draggable (Made by [@fistak](https://github.com/fistak), adapted by [@Killface1980](https://github.com/Killface1980)).
   * ImprovedGasColourMod: Replaces the oxygen overlay with gas overlay. Also visualizes the density (Made by [@fistak](https://github.com/fistak) and [@Killface1980](https://github.com/Killface1980)).
-  * MaterialColor: Adds an overlay option to visualize what a building is made of (Made by [@fistak](https://github.com/fistak)).
-  * OnionPatches: Custom world seeds. DebugHandler hook. Made by [@Moonkis](https://github.com/Moonkis)
+  * MaterialColor: Adds an overlay option to visualize what a building is made of (Made by [@fistak](https://github.com/fistak), adapted by [@Killface1980](https://github.com/Killface1980)).
+  * OnionPatches: Custom world seeds. DebugHandler hook. Made by [@Moonkis](https://github.com/Moonkis), adapted by [@Killface1980](https://github.com/Killface1980)
 
 
 Requirements

--- a/README.md
+++ b/README.md
@@ -16,23 +16,23 @@ This project uses source code of and is based on:
 Examples
 --------
 * AlternateOrdersMod: The Fabricators and Refineries will alternate between infinity orders.
-* CameraControllerMod: Enable further zoom-outs in play and dev mode (taken from Onion patcher).
+* CameraControllerMod: Enable further zoom-outs in play and dev mode (taken from [@Moonkis](https://github.com/Moonkis) Onion patcher).
 * CritterNumberSensor: Sensor for the critter number in a room (thanks to R9MX4 from Klei forum)
-* CustomWorldMod: Enables the player to user custom world sizes. (Remade by Killface)
+* CustomWorldMod: Enables the player to user custom world sizes. (Made by [@Moonkis](https://github.com/Moonkis), remade by [@Killface1980](https://github.com/Killface1980))
+* DraggablePanelMod: Makes panels draggable (Made by [@fistak](https://github.com/fistak)). REQUIRES ONI-Common.
 * DisplayDraggedBoxSize: Shows selected rectangle dimensions using any tool (thanks to fistak from github)
-* DraggablePanelMod: Makes panels draggable. REQUIRES ONI-Common.
 * FastModeMod: Duplicants will build an dig very fast.
-* ImprovedGasColourMod: Replaces the oxygen overly with gas colors. Also visualizes the density (taken from Onion patcher, modified). REQUIRES ONI-Common.
+* ImprovedGasColourMod: Replaces the oxygen overly with gas colors. Also visualizes the density (Made by [@fistak](https://github.com/fistak), modified). REQUIRES ONI-Common.
 * InstantResearchMod: Forces instant research without Debug mode.
 * InsulatedDoorsMod: Doors can be constructed using any buildable element (ie: Abyssalite). Also it adds a new element Insulated Pressure Door
 * InverseElectrolyzerMod: Combines hydrogen and oxygen into steam.
 * LiquidTankMod: Storage for liquids.
-* MaterialColor: Adds an overlay option to visualize what a building is made of (taken from Onion patcher). REQUIRES ONI-Common.
+* MaterialColor: Adds an overlay option to visualize what a building is made of (Made by [@fistak](https://github.com/fistak)). REQUIRES ONI-Common.
 * ONI-Common: Common code for Onion Patches and other mods.
-* OnionPatches: Custom world seeds. DebugHandler hook. REQUIRES ONI-Common.
+* OnionPatches: Custom world seeds. DebugHandler hook. REQUIRES ONI-Common. Made by [@Moonkis](https://github.com/Moonkis)
 * Patches (Do not use): Some incomplete tests.
 * PressureDoorMod: Removes the energy need for the mechanized pressure door and makes it buildable from all material.
-* SensorsMod: It modifies some ranges y automation sensors (taken from Etiam's MateralColor mod pack).
+* SensorsMod: It modifies some ranges y automation sensors (Made by [@fistak](https://github.com/fistak)).
 * SpeedControlMod: Overwrites the method SpeedControlScreen.OnChange. Fast Speed set to behave like Ultra Speed in debug mode.
 * StorageLockerMod: Storage lockers won't need a foundation to be built.
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,8 @@ Examples
 * CameraControllerMod: Enable further zoom-outs in play and dev mode (taken from [@Moonkis](https://github.com/Moonkis) Onion patcher).
 * CritterNumberSensor: Sensor for the critter number in a room (thanks to R9MX4 from Klei forum)
 * CustomWorldMod: Enables the player to user custom world sizes. (Made by [@Moonkis](https://github.com/Moonkis), remade by [@Killface1980](https://github.com/Killface1980))
-* DraggablePanelMod: Makes panels draggable (Made by [@fistak](https://github.com/fistak)). REQUIRES ONI-Common.
 * DisplayDraggedBoxSize: Shows selected rectangle dimensions using any tool (thanks to fistak from github)
 * FastModeMod: Duplicants will build an dig very fast.
-* ImprovedGasColourMod: Replaces the oxygen overly with gas colors. Also visualizes the density (Made by [@fistak](https://github.com/fistak) and [@Killface1980](https://github.com/Killface1980)). REQUIRES ONI-Common.
 * InstantResearchMod: Forces instant research without Debug mode.
 * InsulatedDoorsMod: Doors can be constructed using any buildable element (ie: Abyssalite). Also it adds a new element Insulated Pressure Door
 * InverseElectrolyzerMod: Combines hydrogen and oxygen into steam.
@@ -35,6 +33,11 @@ Examples
 * SensorsMod: It modifies some ranges y automation sensors (Made by [@fistak](https://github.com/fistak)).
 * SpeedControlMod: Overwrites the method SpeedControlScreen.OnChange. Fast Speed set to behave like Ultra Speed in debug mode.
 * StorageLockerMod: Storage lockers won't need a foundation to be built.
+* ONI-Common: Common code, required by these mods:
+  * DraggablePanelMod: Makes panels draggable (Made by [@fistak](https://github.com/fistak)). REQUIRES ONI-Common.
+  * ImprovedGasColourMod: Replaces the oxygen overly with gas colors. Also visualizes the density (Made by [@fistak](https://github.com/fistak) and [@Killface1980](https://github.com/Killface1980)). REQUIRES ONI-Common.
+  * MaterialColor: Adds an overlay option to visualize what a building is made of (Made by [@fistak](https://github.com/fistak)). REQUIRES ONI-Common.
+  * OnionPatches: Custom world seeds. DebugHandler hook. REQUIRES ONI-Common. Made by [@Moonkis](https://github.com/Moonkis)
 
 
 Requirements

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Examples
 * CameraControllerMod: Enable further zoom-outs in play and dev mode (taken from [@Moonkis](https://github.com/Moonkis) Onion patcher).
 * CritterNumberSensor: Sensor for the critter number in a room (thanks to R9MX4 from Klei forum)
 * CustomWorldMod: Enables the player to user custom world sizes. (Made by [@Moonkis](https://github.com/Moonkis), remade by [@Killface1980](https://github.com/Killface1980))
+* FastModeMod: Duplicants will build and dig very fast.
 * DisplayDraggedBoxSize: Shows selected rectangle dimensions using any tool (thanks to fistak from github)
-* FastModeMod: Duplicants will build an dig very fast.
 * InstantResearchMod: Forces instant research without Debug mode.
 * InsulatedDoorsMod: Doors can be constructed using any buildable element (ie: Abyssalite). Also it adds a new element Insulated Pressure Door
 * InverseElectrolyzerMod: Combines hydrogen and oxygen into steam.
@@ -30,14 +30,14 @@ Examples
 * OnionPatches: Custom world seeds. DebugHandler hook. REQUIRES ONI-Common. Made by [@Moonkis](https://github.com/Moonkis)
 * Patches (Do not use): Some incomplete tests.
 * PressureDoorMod: Removes the energy need for the mechanized pressure door and makes it buildable from all material.
-* SensorsMod: It modifies some ranges y automation sensors (Made by [@fistak](https://github.com/fistak)).
+* SensorsMod: Allows for increased ranges in automation sensors (Made by [@fistak](https://github.com/fistak)).
 * SpeedControlMod: Overwrites the method SpeedControlScreen.OnChange. Fast Speed set to behave like Ultra Speed in debug mode.
 * StorageLockerMod: Storage lockers won't need a foundation to be built.
 * ONI-Common: Common code, required by these mods:
-  * DraggablePanelMod: Makes panels draggable (Made by [@fistak](https://github.com/fistak)). REQUIRES ONI-Common.
-  * ImprovedGasColourMod: Replaces the oxygen overly with gas colors. Also visualizes the density (Made by [@fistak](https://github.com/fistak) and [@Killface1980](https://github.com/Killface1980)). REQUIRES ONI-Common.
-  * MaterialColor: Adds an overlay option to visualize what a building is made of (Made by [@fistak](https://github.com/fistak)). REQUIRES ONI-Common.
-  * OnionPatches: Custom world seeds. DebugHandler hook. REQUIRES ONI-Common. Made by [@Moonkis](https://github.com/Moonkis)
+  * DraggablePanelMod: Makes panels draggable (Made by [@fistak](https://github.com/fistak)).
+  * ImprovedGasColourMod: Replaces the oxygen overlay with gas overlay. Also visualizes the density (Made by [@fistak](https://github.com/fistak) and [@Killface1980](https://github.com/Killface1980)).
+  * MaterialColor: Adds an overlay option to visualize what a building is made of (Made by [@fistak](https://github.com/fistak)).
+  * OnionPatches: Custom world seeds. DebugHandler hook. Made by [@Moonkis](https://github.com/Moonkis)
 
 
 Requirements


### PR DESCRIPTION
I think there is not enough credit given to the mod authors. For example there is not a single one given to @Moonkis - author of [OnionPatcher, the first modpack for ONI](https://forums.kleientertainment.com/topic/74277-modtool-onionpatcher/) ([GitHub repo](https://github.com/Moonkis/onion-patcher)). We joined our mods together in my [MaterialColor modpack](https://forums.kleientertainment.com/topic/81296-mod159-materialcolor-onionpatcher/) ([GitHub repo](https://github.com/fistak/MaterialColor))

Also I don't think they are neither consistent or sufficient for me and @Killface1980 - various names are used and no links. It's really hard to track who were involved because the code was moved across several repositories already.

Of course I'm glad that @javisar and @Killface1980 took care of creating the modloader and porting our mods to Harmony. We already discussed and wanted to do something similar with @Moonkis and [noisycat@kleiforum](https://forums.kleientertainment.com/profile/1025859-noisycat/) (Sorry I don't know his GitHub profile so here's his discord tag: noisycat#9418).

I think these changes I made should be fine, but I know this subject needs a bit of discussion first, so I'm open to suggestions. I have also corrected some typos in README.md.