### PR TITLE
Fix issue with gates not pushing fluid

### DIFF
--- a/Source/FluidWarpMod/WarpSpaceManager.cs
+++ b/Source/FluidWarpMod/WarpSpaceManager.cs
@@ -242,12 +242,16 @@ namespace FluidWarpMod
                     ConduitFlow.ConduitContents providerContents = providerConduit.GetContents(flowManager);
                     if (!SimHashes.Vacuum.Equals(providerContents.element))
                     {
-#if DEBUG
                         ConduitFlow.Conduit requestorConduit = flowManager.GetConduit(toCell);
                         ConduitFlow.ConduitContents requestorContents = requestorConduit.GetContents(flowManager);
+#if DEBUG
                         Logger.LogFormat("Trying to move {0} kg. of {1} from {2} to {3}", providerContents.mass, providerContents.element, fromCell, toCell);
                         Logger.LogFormat("Requestor contents is: {0} kg. of {1}", requestorContents.mass, requestorContents.element);
 #endif
+                        if (requestorContents.mass < 1f && requestorContents.element != providerContents.element && requestorContents.element != SimHashes.Vacuum)
+                        {
+                            flowManager.RemoveElement(requestorConduit, requestorContents.mass);
+                        }
                         float addedMass = flowManager.AddElement(toCell, providerContents.element, providerContents.mass, providerContents.temperature, providerContents.diseaseIdx, providerContents.diseaseCount);
                         Game.Instance.accumulators.Accumulate(provider.AccumulatorHandle, addedMass);
                         if (addedMass > 0f)


### PR DESCRIPTION
This fixes the issue with gates suddenly stopping work. From the debugging, I found that when the gates stop working, it is because the requestor has some very small (< 0.005g) amount of element that doesn't match the provider element, and for some reason, that small amount stays in the pipe without being pushed anywhere. This commit detects this situation and just deletes the small amount of element.

Note, I'm super new to ONI and ONI modding, so this may be somewhat of an inefficient fix, but from my testing seems to work pretty well. Feel free to reject and write up a different way to accomplish this.